### PR TITLE
Add ComfyUI inventory watcher utility

### DIFF
--- a/app/utils/comfy_inventory.py
+++ b/app/utils/comfy_inventory.py
@@ -1,0 +1,158 @@
+"""Shared helpers for ComfyUI inventory tracking."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, MutableMapping, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class InventoryItem:
+    """Normalized description of a tracked filesystem object."""
+
+    absolute_path: str
+    relative_path: Optional[str]
+    kind: str
+    size: int
+    modified: float
+
+    def as_json_ready(self) -> Dict[str, object]:
+        """Return a JSON serialisable payload for the inventory file."""
+
+        payload = asdict(self)
+        payload["modified"] = time.strftime(
+            "%Y-%m-%dT%H:%M:%S%z", time.localtime(self.modified)
+        )
+        return payload
+
+
+def normalise_path(path: Path) -> Path:
+    """Return a resolved version of ``path`` without forcing existence."""
+
+    try:
+        return path.expanduser().resolve()
+    except FileNotFoundError:
+        return path.expanduser().absolute()
+
+
+def relative_to_base(path: Path, base: Optional[Path]) -> Optional[str]:
+    """Return ``path`` relative to ``base`` when possible."""
+
+    if base is None:
+        return None
+
+    try:
+        return str(path.relative_to(base))
+    except ValueError:
+        return None
+
+
+def create_inventory_item(path: Path, base: Optional[Path]) -> Optional[InventoryItem]:
+    """Build inventory metadata for ``path``."""
+
+    path = normalise_path(path)
+
+    if not path.exists():
+        return None
+
+    stats = path.stat()
+    kind = "directory" if path.is_dir() else "file"
+
+    return InventoryItem(
+        absolute_path=str(path),
+        relative_path=relative_to_base(path, base),
+        kind=kind,
+        size=0 if path.is_dir() else stats.st_size,
+        modified=stats.st_mtime,
+    )
+
+
+def scan_inventory(
+    roots: Iterable[Path],
+    base: Optional[Path],
+) -> Dict[str, Dict[str, object]]:
+    """Build an inventory dictionary for the provided ``roots``."""
+
+    inventory: Dict[str, Dict[str, object]] = {}
+
+    for root in roots:
+        root = normalise_path(root)
+        if not root.exists():
+            logger.warning("Skipping missing path: %s", root)
+            continue
+
+        for current in _iter_existing_paths(root):
+            item = create_inventory_item(current, base)
+            if item is None:
+                continue
+            inventory[item.absolute_path] = item.as_json_ready()
+
+    return inventory
+
+
+def _iter_existing_paths(root: Path) -> Iterator[Path]:
+    """Yield ``root`` and all descendants."""
+
+    yield root
+    if root.is_dir():
+        for child in root.rglob("*"):
+            yield child
+
+
+def dump_inventory(path: Path, inventory: MutableMapping[str, Dict[str, object]]) -> None:
+    """Persist ``inventory`` as prettified JSON."""
+
+    ordered_items = sorted(
+        (item for item in inventory.values()),
+        key=lambda item: (
+            item.get("kind", ""),
+            item.get("relative_path") or item.get("absolute_path"),
+        ),
+    )
+
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path.write_text(json.dumps(ordered_items, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def build_default_watchlist(
+    comfy_root: Path,
+    downloads: Iterable[Path],
+    extras: Iterable[Path],
+) -> list[Path]:
+    """Return the set of directories that should be monitored."""
+
+    watchlist: list[Path] = []
+    comfy_root = normalise_path(comfy_root)
+
+    candidates = [
+        comfy_root,
+        comfy_root / "models",
+        comfy_root / "models" / "checkpoints",
+        comfy_root / "models" / "vae",
+        comfy_root / "models" / "loras",
+        comfy_root / "custom_nodes",
+        comfy_root / "input",
+        comfy_root / "output",
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            watchlist.append(candidate)
+        else:
+            logger.debug("Optional path missing: %s", candidate)
+
+    for dl in downloads:
+        watchlist.append(normalise_path(dl))
+
+    for extra in extras:
+        watchlist.append(normalise_path(extra))
+
+    return watchlist

--- a/docs/comfy_ui_inventory.md
+++ b/docs/comfy_ui_inventory.md
@@ -1,0 +1,64 @@
+# ComfyUI Inventory Tracking
+
+This note summarises how ComfyUI organises its assets and explains the new
+`scripts/comfy_inventory_watcher.py` utility that keeps a live inventory of the
+installation.  It is intended to address the requirements captured in
+`tasks/Task1.md`.
+
+## How ComfyUI manages assets
+
+ComfyUI is a node-based Stable Diffusion interface.  The upstream project
+focuses on orchestrating inference pipelines and delegates model management to
+regular filesystem folders.  A typical installation contains:
+
+- `models/` with subdirectories such as `checkpoints/`, `vae/`, `loras/`,
+  `controlnet/`, etc.  ComfyUI reads whatever files exist in those folders at
+  startup; there is no background watcher that reports newly added or deleted
+  models.
+- `custom_nodes/` containing Python packages that provide extra nodes.  When a
+  module is added or removed, ComfyUI discovers it on the next launch.
+- `input/` and `output/` folders used for workflow assets and renders.
+
+The project does **not** ship an official inventory or auditing mechanism for
+models, custom nodes, or download folders.  Community launchers such as ComfyUI
+Manager can install content, but they still rely on the same directories.  As a
+result, keeping a "current inventory" requires an external watcher.
+
+## Inventory watcher overview
+
+`scripts/comfy_inventory_watcher.py` provides a small CLI to monitor the
+directories above and any download locations you want to track.  It produces a
+JSON file (default: `comfy_inventory.json`) that lists every file and directory
+with its size, last-modified time, and a path relative to the ComfyUI parent
+folder when possible.
+
+Key behaviours:
+
+- Runs happily from the directory above `ComfyUI` (default assumption) but
+  allows overriding `--comfy-root`, `--downloads`, and `--extra` watch paths.
+- Performs a full scan on startup so the inventory reflects the current state
+  before live monitoring begins.
+- Updates the JSON atomically on each change so other processes can read a
+  consistent snapshot.
+- Ignores noisy directory modification events while still tracking creations,
+  deletions, moves, and file updates.
+
+Example usage:
+
+```bash
+python scripts/comfy_inventory_watcher.py \
+  --comfy-root ./ComfyUI \
+  --downloads ~/Downloads \
+  --extra ~/stable-diffusion-assets
+```
+
+This command creates/updates `comfy_inventory.json` in the working directory and
+logs changes as they happen.
+
+## Am I reinventing something ComfyUI already does?
+
+No.  ComfyUI itself only reads the filesystem when you launch the application or
+when you manually reload custom nodes; it does not maintain a historical record
+of models or downloads.  The new watcher complements ComfyUI by providing the
+continuous inventory you described, especially for folders like `~/Downloads`
+where models and custom nodes are staged before installation.

--- a/scripts/comfy_inventory_watcher.py
+++ b/scripts/comfy_inventory_watcher.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Utilities for tracking ComfyUI assets in real time.
+
+This module exposes a CLI entrypoint that keeps an inventory of files inside a
+ComfyUI installation and any related download folders.  It is designed to be
+run from the directory immediately above ``ComfyUI`` (as requested in
+``tasks/Task1.md``) but accepts explicit paths for flexibility.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import signal
+import sys
+import threading
+from pathlib import Path
+from typing import Dict, MutableMapping, Optional
+
+from watchdog.events import DirModifiedEvent, FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from app.utils.comfy_inventory import (
+    build_default_watchlist,
+    create_inventory_item,
+    dump_inventory,
+    normalise_path,
+    scan_inventory,
+)
+
+logger = logging.getLogger("comfy_inventory")
+
+
+class InventoryEventHandler(FileSystemEventHandler):
+    """Watchdog handler that keeps the on-disk inventory in sync."""
+
+    def __init__(
+        self,
+        inventory: MutableMapping[str, Dict[str, object]],
+        lock: threading.Lock,
+        base: Optional[Path],
+        output_file: Path,
+        log_events: bool,
+    ) -> None:
+        super().__init__()
+        self.inventory = inventory
+        self.lock = lock
+        self.base = base
+        self.output_file = output_file
+        self.log_events = log_events
+
+    # ``FileSystemEventHandler`` dispatches to both file and directory specific
+    # methods.  We treat them uniformly by delegating to helper routines.
+
+    def on_created(self, event: FileSystemEvent) -> None:  # noqa: D401
+        """Update the inventory when a file or directory is created."""
+
+        self._handle_creation(event.src_path)
+
+    def on_modified(self, event: FileSystemEvent) -> None:  # noqa: D401
+        """Update metadata when a file or directory is modified."""
+
+        if isinstance(event, (DirModifiedEvent,)):
+            # Directory modifications are extremely noisy and rarely provide
+            # useful timestamp updates for ComfyUI assets.
+            return
+        self._handle_creation(event.src_path)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:  # noqa: D401
+        """Remove entries when a path disappears."""
+
+        self._handle_deletion(event.src_path)
+
+    def on_moved(self, event: FileSystemEvent) -> None:  # noqa: D401
+        """Handle rename/move events."""
+
+        src = getattr(event, "src_path", None)
+        dest = getattr(event, "dest_path", None)
+
+        if src:
+            self._handle_deletion(src)
+        if dest:
+            self._handle_creation(dest)
+
+    # Helper routines -----------------------------------------------------------------
+
+    def _handle_creation(self, raw_path: str) -> None:
+        path = Path(raw_path)
+        item = create_inventory_item(path, self.base)
+        if item is None:
+            return
+
+        if self.log_events:
+            logger.info("Inventory update: %s", item.absolute_path)
+
+        with self.lock:
+            self.inventory[item.absolute_path] = item.as_json_ready()
+            dump_inventory(self.output_file, self.inventory)
+
+    def _handle_deletion(self, raw_path: str) -> None:
+        absolute = str(normalise_path(Path(raw_path)))
+        with self.lock:
+            removed = self.inventory.pop(absolute, None)
+            if removed is None:
+                return
+
+            if self.log_events:
+                logger.info("Inventory removal: %s", absolute)
+
+            dump_inventory(self.output_file, self.inventory)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Monitor ComfyUI assets and maintain an inventory JSON file.",
+    )
+    parser.add_argument(
+        "--comfy-root",
+        type=Path,
+        default=Path("ComfyUI"),
+        help="Path to the ComfyUI installation (default: ./ComfyUI).",
+    )
+    parser.add_argument(
+        "--downloads",
+        type=Path,
+        action="append",
+        default=[],
+        help="Additional download directories to track (can be repeated).",
+    )
+    parser.add_argument(
+        "--extra",
+        type=Path,
+        action="append",
+        default=[],
+        help="Any extra directories to include in the watchlist.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("comfy_inventory.json"),
+        help="Where to write the inventory file.",
+    )
+    parser.add_argument(
+        "--poll",
+        type=float,
+        default=1.0,
+        help="Polling interval for watchdog when in polling mode (seconds).",
+    )
+    parser.add_argument(
+        "--log-events",
+        action="store_true",
+        help="Emit info logs whenever the inventory changes.",
+    )
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=None,
+        help=(
+            "Optional base directory used to compute relative paths. "
+            "Defaults to the parent of --comfy-root if available."
+        ),
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point for the CLI script."""
+
+    args = parse_args(argv)
+
+    if not logging.getLogger().handlers:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s [%(levelname)s] %(message)s",
+        )
+
+    comfy_root = normalise_path(args.comfy_root)
+    base = normalise_path(args.base) if args.base else comfy_root.parent
+
+    watchlist = build_default_watchlist(
+        comfy_root=comfy_root,
+        downloads=args.downloads,
+        extras=args.extra,
+    )
+
+    if not watchlist:
+        logger.error("No valid directories to monitor.")
+        return 1
+
+    inventory = scan_inventory(watchlist, base)
+    output_file = normalise_path(args.output)
+
+    lock = threading.Lock()
+    dump_inventory(output_file, inventory)
+
+    handler = InventoryEventHandler(
+        inventory=inventory,
+        lock=lock,
+        base=base,
+        output_file=output_file,
+        log_events=args.log_events,
+    )
+
+    observers: list[Observer] = []
+    for path in watchlist:
+        observer = Observer()
+        observer.schedule(handler, str(path), recursive=True)
+        observer.daemon = True
+        observer.start()
+        observers.append(observer)
+        logger.info("Watching %s", path)
+
+    stop_event = threading.Event()
+
+    def _signal_handler(signum, frame):  # noqa: D401
+        logger.info("Received signal %s, shutting down.", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _signal_handler)
+    signal.signal(signal.SIGTERM, _signal_handler)
+
+    try:
+        while not stop_event.is_set():
+            stop_event.wait(args.poll)
+    finally:
+        for observer in observers:
+            observer.stop()
+        for observer in observers:
+            observer.join()
+
+    logger.info("Inventory watcher stopped.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI bridge
+    sys.exit(main())

--- a/tests/unit/test_comfy_inventory_watcher.py
+++ b/tests/unit/test_comfy_inventory_watcher.py
@@ -1,0 +1,98 @@
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from app.utils.comfy_inventory import create_inventory_item, dump_inventory, normalise_path
+
+
+def test_create_inventory_item_file_and_directory(tmp_path):
+    base = tmp_path
+
+    file_path = base / "test.txt"
+    file_path.write_text("hello")
+    file_item = create_inventory_item(file_path, base)
+
+    assert file_item is not None
+    assert file_item.kind == "file"
+    assert file_item.size == 5
+    assert file_item.relative_path == "test.txt"
+
+    dir_path = base / "models"
+    dir_path.mkdir()
+    dir_item = create_inventory_item(dir_path, base)
+
+    assert dir_item is not None
+    assert dir_item.kind == "directory"
+    assert dir_item.size == 0
+    assert dir_item.relative_path == "models"
+
+
+def test_dump_inventory_orders_items(tmp_path):
+    output = tmp_path / "inventory.json"
+    inventory = {
+        "/tmp/models": {
+            "absolute_path": "/tmp/models",
+            "relative_path": "ComfyUI/models",
+            "kind": "directory",
+            "size": 0,
+            "modified": "2024-01-01T00:00:00+0000",
+        },
+        "/tmp/model.ckpt": {
+            "absolute_path": "/tmp/model.ckpt",
+            "relative_path": "ComfyUI/models/checkpoints/model.ckpt",
+            "kind": "file",
+            "size": 42,
+            "modified": "2024-01-01T00:00:00+0000",
+        },
+    }
+
+    dump_inventory(output, inventory)
+
+    data = json.loads(output.read_text())
+    assert data[0]["kind"] == "directory"
+    assert data[1]["kind"] == "file"
+
+
+def test_handler_updates_inventory(tmp_path):
+    pytest.importorskip("watchdog", reason="watchdog dependency is required for handler tests")
+    from scripts.comfy_inventory_watcher import InventoryEventHandler
+
+    output = tmp_path / "inventory.json"
+    inventory: dict[str, dict[str, object]] = {}
+    handler = InventoryEventHandler(
+        inventory=inventory,
+        lock=threading.Lock(),
+        base=tmp_path,
+        output_file=output,
+        log_events=False,
+    )
+
+    class Event:
+        def __init__(self, src: Path, dest: Path | None = None):
+            self.src_path = str(src)
+            self.dest_path = str(dest) if dest else None
+            self.is_directory = False
+
+    file_path = tmp_path / "node.py"
+    file_path.write_text("print('hi')")
+
+    handler.on_created(Event(file_path))
+    assert len(inventory) == 1
+
+    contents = json.loads(output.read_text())
+    assert contents[0]["absolute_path"] == str(normalise_path(file_path))
+
+    file_path.write_text("print('hello')")
+    handler.on_modified(Event(file_path))
+    assert len(inventory) == 1
+
+    file_path.unlink()
+    handler.on_deleted(Event(file_path))
+    assert inventory == {}
+    assert json.loads(output.read_text()) == []
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__])


### PR DESCRIPTION
## Summary
- add reusable helpers for scanning ComfyUI directories and emitting inventory JSON
- introduce a CLI watcher script to track ComfyUI assets and related download folders in real time
- document ComfyUI asset management assumptions and cover the helpers with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ee88759510832b8d9a654a98b7dc99